### PR TITLE
Mathjax CDN is no more

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ September, I&#8217;ve been thinking about ways to improve &hellip;">
   <!--Fonts from Google"s Web font directory at http://google.com/webfonts -->
 <link href="http://fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css">
 <link href="http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css">
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=AM_HTMLorMML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=AM_HTMLorMML"></script>
 <script>
 MathJax.Hub.Config({
   asciimath2jax: {


### PR DESCRIPTION
See https://www.mathjax.org/cdn-shutting-down/

I wanted to read http://pcwalton.github.io/blog/2015/12/21/drawing-css-box-shadows-in-webrender/ , but the math isn't properly displayed.